### PR TITLE
Use Secondary Google Calendar

### DIFF
--- a/frontend/src/firebase/auth.js
+++ b/frontend/src/firebase/auth.js
@@ -25,9 +25,7 @@ const auth = getAuth(app);
 const googleProvider = new GoogleAuthProvider();
 
 // Google auth with calendar scope for calendar operations
-googleProvider.addScope(
-  "https://www.googleapis.com/auth/calendar.events.owned"
-);
+googleProvider.addScope("https://www.googleapis.com/auth/calendar.app.created");
 
 // Basic Google auth without calendar scope for initial signup/login
 const basicGoogleProvider = new GoogleAuthProvider();

--- a/frontend/src/firebase/google-calendar.js
+++ b/frontend/src/firebase/google-calendar.js
@@ -131,10 +131,9 @@ export async function createCalendarEventsFromSchedule(
         const [startHour, startMin] = startTime.split(":").map(Number);
 
         // Format the time for EXDATE and RDATE (HHMMSS format)
-        const formattedStartTime = `T${startHour.padStart(
-          2,
-          "0"
-        )}${startMin.padStart(2, "0")}00`;
+        const formattedStartTime = `T${startHour
+          .toString()
+          .padStart(2, "0")}${startMin.toString().padStart(2, "0")}00`;
 
         const exDateString =
           datesToExclude.length > 0


### PR DESCRIPTION
Modifying the user's primary Google Calendar requires restricted scopes (scopes that require app verification) and are unnecessary for UniCal.

Instead, UniCal now creates a new secondary calendar for the user and adds events to the secondary calendar. And UniCal cannot have access to the user's primary calendar. Therefore, the user's calendar primary data cannot be read by UniCal and no harm can be done to the user. Consequently, UniCal no longer requires verification to add events to the user's Google Calendar.